### PR TITLE
Configure carbon-relay to optionally use pypy

### DIFF
--- a/templates/etc/init.d/carbon-relay.erb
+++ b/templates/etc/init.d/carbon-relay.erb
@@ -11,16 +11,17 @@
 # Short-Description: Start/Stop carbon-relay
 # Description: Enables Graphites carbon-relay data routing engine
 ### END INIT INFO
+export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}<%= scope['graphite::gr_pythonpath'] %>"
 
 case "$1" in
 	start)
-		python /opt/graphite/bin/carbon-relay.py start
+		<%= scope['graphite::gr_interpreter'] %> /opt/graphite/bin/carbon-relay.py start
 		;;
 	stop)
-		python /opt/graphite/bin/carbon-relay.py stop
+		<%= scope['graphite::gr_interpreter'] %> /opt/graphite/bin/carbon-relay.py stop
 		;;
 	status)
-		python /opt/graphite/bin/carbon-relay.py status
+		<%= scope['graphite::gr_interpreter'] %> /opt/graphite/bin/carbon-relay.py status
 		;;
 	restart)
 		$0 stop ; sleep 3 ; $0 start


### PR DESCRIPTION
With this PR, graphite::gr_interpreter will configure interpreter for both carbon-cache and carbon-relay.